### PR TITLE
Remove unused typescript dependencies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,5 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-  "typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
-
   // The number of spaces a tab is equal to.
   "editor.tabSize": 2,
 

--- a/package.json
+++ b/package.json
@@ -37,9 +37,7 @@
       "expect" 
     ]
   },
-  "devDependencies": {
-    "@types/mocha": "^2.2.32",
-    "@types/node": "^6.0.40",
+  "devDependencies": {    
     "babel-cli": "^6.18.0",
     "babel-jest": "^18.0.0",
     "babel-polyfill": "^6.20.0",
@@ -49,7 +47,6 @@
     "mocha": "^2.3.3",
     "rimraf": "^2.5.4",
     "standard": "^8.6.0",
-    "typescript": "^2.0.3",
     "vscode": "^1.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
The Typescript dependencies were removed because the project doesn't use Typescript.