### PR TITLE
chore: update workflow for new main default branch

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -2,19 +2,20 @@ name: Test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2-beta
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: '16.7.0'
 
     - run: npm install
+    - run: npm run build
     - run: npm test

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This extension can be installed with one the following methods:
 
 Launch the Command Pallete **(Cmd+Shift+P / Ctrl+Shift+P)** and type `random` to view all the available data generators. Select one of them and press **Enter**.
 
-![Screen](https://raw.githubusercontent.com/jrebocho/vscode-random/master/images/vscode-random-screen.gif)
+![Screen](https://raw.githubusercontent.com/jrebocho/vscode-random/main/images/vscode-random-screen.gif)
 
 Random values generation is also supported when using **multiple editors**.
 

--- a/package.json
+++ b/package.json
@@ -372,7 +372,7 @@
         ]
     },
     "scripts": {
-        "compile": "rimraf build & babel src --out-dir build",
+        "build": "rimraf build & babel src --out-dir build",
         "pretest": "eslint ./{src,tests,mocks}/**/*.js",
         "test": "jest --ci",
         "test:watch": "jest --watch",


### PR DESCRIPTION
The default branch is now `main`. The build workflow was updated to reflect that change.